### PR TITLE
Add two missing ICMP types

### DIFF
--- a/config/icmptypes/timestamp-reply.xml
+++ b/config/icmptypes/timestamp-reply.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<icmptype>
+  <short>Timestamp Reply</short>
+  <description>This message is used to reply to a timestamp message.</description>
+  <destination ipv4="yes"/>
+  <destination ipv6="no"/>
+</icmptype>

--- a/config/icmptypes/timestamp-request.xml
+++ b/config/icmptypes/timestamp-request.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<icmptype>
+  <short>Timestamp Request</short>
+  <description>This message is used for time synchronization.</description>
+  <destination ipv4="yes"/>
+  <destination ipv6="no"/>
+</icmptype>


### PR DESCRIPTION
The following ICMP types are not included by default in the available
configuration:

Type 13 - Timestamp Request [1]
Type 14 - Timestamp Request [1]

This is useful to address [2].

[1] http://tools.ietf.org/html/rfc792
[2] https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-1999-0524