### PR TITLE
Control ebtables as well as ipXtables

### DIFF
--- a/src/firewall/core/fw.py
+++ b/src/firewall/core/fw.py
@@ -535,12 +535,16 @@ class Firewall:
             self._ip4tables.flush()
         if self.ip6tables_enabled:
             self._ip6tables.flush()
+        if self.ebtables_enabled:
+            self._ebtables.flush()
 
     def _set_policy(self, policy, which="used"):
         if self.ip4tables_enabled:
             self._ip4tables.set_policy(policy, which)
         if self.ip6tables_enabled:
             self._ip6tables.set_policy(policy, which)
+        if self.ebtables_enabled:
+            self._ebtables.set_policy(policy, which)
 
     # rule function used in handle_ functions
 


### PR DESCRIPTION
# The Main Issue

Tables in ebtables are not flushed and their policies are not changed on following events:

*  When firewalld is started/stopped
*  When firewalld is reloaded
*  When panic mode is enabled/disabled

I noticed this issue when I'm using `eb` passthroughs (I couldn't use direct rules because it lacks support of ebtables [firewalld **says** it's supported but I couldn't get it working] but that's another story). Because `firewall-cmd --reload` doesn't flush tables in ebtables, all rules are duplicated.

## Reproduction
```
$ # Testing with empty filter table
$ ebtables -t filter -L
Bridge table: filter

Bridge chain: INPUT, entries: 0, policy: ACCEPT

Bridge chain: FORWARD, entries: 0, policy: ACCEPT

Bridge chain: OUTPUT, entries: 0, policy: ACCEPT
$ # Add a dummy rule
$ firewall-cmd --direct --add-passthrough eb -t filter -A FORWARD -j ACCEPT
$ ebtables -t filter -L
Bridge table: filter

Bridge chain: INPUT, entries: 0, policy: ACCEPT

Bridge chain: FORWARD, entries: 0, policy: ACCEPT
-j ACCEPT

Bridge chain: OUTPUT, entries: 0, policy: ACCEPT
$ firewall-cmd --direct --get-all-passthroughs
eb -t filter -A FORWARD -j ACCEPT
$ firewall-cmd --reload
success
$ ebtables -t filter -L
Bridge table: filter

Bridge chain: INPUT, entries: 0, policy: ACCEPT

Bridge chain: FORWARD, entries: 0, policy: ACCEPT
-j ACCEPT
-j ACCEPT

Bridge chain: OUTPUT, entries: 0, policy: ACCEPT
$ # You now see duplicate rules
$
```
This example is harmless but in general, all rules before `reload` are remaining. They can cause several issues (depend on actual passthrough and other firewalld features we use).

## Severity (when I noticed this issue)
They were critical in my environment since I upgraded CentOS from 7.0 to 7.1. I used to workaround these on CentOS 7.0 by adding "delete rules and then append" passthroughs. However, firewalld in CentOS 7.1 doesn't allow such trick (because commit a5d73a5ec3714eac23d46edb9c02417b410c0d9e is merged) so there's no way but patching firewalld itself.

## Cause
This is because `Firewall._flush` and `Firewall._set_policy` doesn't control ebtables.


# Proposal
This commit adds `flush` and `set_policy` calls for ebtables to control ebtables as well as ipXtables and prevent issues when ebtables is used.