### PR TITLE
ebtables support

### DIFF
--- a/src/firewall/core/ebtables.py
+++ b/src/firewall/core/ebtables.py
@@ -33,9 +33,14 @@ BUILT_IN_CHAINS = {
 
 DEFAULT_RULES = { }
 OUR_CHAINS = {}  # chains created by firewalld
-OUR_CHAINS["broute"] = set()
-OUR_CHAINS["nat"] = set()
-OUR_CHAINS["filter"] = set()
+
+for table in BUILT_IN_CHAINS.keys():
+    DEFAULT_RULES[table] = [ ]
+    OUR_CHAINS[table] = set()
+    for chain in BUILT_IN_CHAINS[table]:
+        DEFAULT_RULES[table].append("-N %s_direct -P RETURN" % chain)
+        DEFAULT_RULES[table].append("-I %s 1 -j %s_direct" % (chain, chain))
+        OUR_CHAINS[table].add("%s_direct" % chain)
 
 class ebtables:
     ipv = "ipv4"

--- a/src/firewall/core/ebtables.py
+++ b/src/firewall/core/ebtables.py
@@ -97,9 +97,6 @@ class ebtables:
         else:
             tables = list(BUILT_IN_CHAINS.keys())
 
-        if "nat" in tables:
-            tables.remove("nat") # nat can not set policies in nat table
-
         for table in tables:
             for chain in BUILT_IN_CHAINS[table]:
                 self.__run([ "-t", table, "-P", chain, policy ])

--- a/src/firewall/core/ebtables.py
+++ b/src/firewall/core/ebtables.py
@@ -43,8 +43,6 @@ for table in BUILT_IN_CHAINS.keys():
         OUR_CHAINS[table].add("%s_direct" % chain)
 
 class ebtables:
-    ipv = "ipv4"
-
     def __init__(self):
         self._command = "/sbin/ebtables"
 

--- a/src/firewall/core/fw.py
+++ b/src/firewall/core/fw.py
@@ -535,12 +535,16 @@ class Firewall:
             self._ip4tables.flush()
         if self.ip6tables_enabled:
             self._ip6tables.flush()
+        if self.ebtables_enabled:
+            self._ebtables.flush()
 
     def _set_policy(self, policy, which="used"):
         if self.ip4tables_enabled:
             self._ip4tables.set_policy(policy, which)
         if self.ip6tables_enabled:
             self._ip6tables.set_policy(policy, which)
+        if self.ebtables_enabled:
+            self._ebtables.set_policy(policy, which)
 
     # rule function used in handle_ functions
 

--- a/src/firewall/core/fw_direct.py
+++ b/src/firewall/core/fw_direct.py
@@ -186,6 +186,8 @@ class FirewallDirect:
         else:
             rule.append("-X")
         rule.append(chain)
+        if add and ipv == "eb":
+            rule += [ "-P", "RETURN" ]
 
         try:
             self._fw.rule(ipv, rule)


### PR DESCRIPTION
In firewalld, ebtables support was insufficient. These commits will add full ebtables support (we can now add direct rules as well as iptables and will not cause specific issues).

I personally use firewalld+ebtables in the gateway to filter some L2 traffic (e.g. ARP) and I hope minimum support of ebtables is added to firewalld (e.g. use direct rules **just like** ipXtables).



# Issue 1 : Tables in ebtables are not flushed

Tables in ebtables are not flushed and their policies are not changed on following events:

*  When firewalld is started/stopped
*  When firewalld is reloaded
*  When panic mode is enabled/disabled

I noticed this issue when I'm using `eb` passthroughs (I couldn't use direct rules because it lacks support of ebtables; I'm describing this issue in "Issue 2" section). Because `firewall-cmd --reload` doesn't flush tables in ebtables, all rules are duplicated after reloading.


## Reproduction

```
$ # Testing with empty filter table
$ ebtables -t filter -L
Bridge table: filter

Bridge chain: INPUT, entries: 0, policy: ACCEPT

Bridge chain: FORWARD, entries: 0, policy: ACCEPT

Bridge chain: OUTPUT, entries: 0, policy: ACCEPT
$ # Add a dummy rule
$ firewall-cmd --direct --add-passthrough eb -t filter -A FORWARD -j ACCEPT
$ ebtables -t filter -L
Bridge table: filter

Bridge chain: INPUT, entries: 0, policy: ACCEPT

Bridge chain: FORWARD, entries: 0, policy: ACCEPT
-j ACCEPT

Bridge chain: OUTPUT, entries: 0, policy: ACCEPT
$ firewall-cmd --direct --get-all-passthroughs
eb -t filter -A FORWARD -j ACCEPT
$ firewall-cmd --reload
success
$ ebtables -t filter -L
Bridge table: filter

Bridge chain: INPUT, entries: 0, policy: ACCEPT

Bridge chain: FORWARD, entries: 0, policy: ACCEPT
-j ACCEPT
-j ACCEPT

Bridge chain: OUTPUT, entries: 0, policy: ACCEPT
$ # You now see duplicate rules
$
```

This example is harmless but in general, all rules before `reload` remain. They can cause several issues (depend on actual passthrough and other firewalld features we use).

## Severity

High (this issue prevents using ebtables+firewalld).

They were critical in my environment since I upgraded CentOS from 7.0 to 7.1. I used to workaround these on CentOS 7.0 by adding "delete rules and then append" passthroughs. However, firewalld in CentOS 7.1 doesn't allow such trick (because commit a5d73a5ec3714eac23d46edb9c02417b410c0d9e is merged) so there's no way but patching firewalld itself.

## Fix

Commit 3d52b723dbc5fa8857bffb5400b7dcd1a9a02f84 adds `flush` and `set_policy` calls for ebtables to control ebtables as well as ipXtables and prevent issues when ebtables is used.



# Issue 2 : Direct `eb` rules cannot be used

Direct rules for ebtables cannot be used like ipXtables because:

* firewalld will not create chains for direct rules.
* firewalld will handle certain chain names as reserved.

Because firewalld will not create `%s_direct` (`%s` : original built-in chain name) chains, we cannot simply add `eb` direct rules. We cannot create such chain either (in the latest version of firewalld) using `--add-chain` because name `%s_direct` is reserved.

There's more. Unlike ipXtables, all ebtables chains have default policy (default: `ACCEPT`) and must be set to `RETURN` for multi-chain configurations.

## Severity

High (to use direct rules with `eb`, some fix will be needed)

## Fix

Commit 17b92895a3b10617d7283f64f35be55853faefdf adds chains for direct rules and commit b4885b8f44b708e6f71ff7b067de0851bc520dd5 makes custom direct chains to `RETURN`.

## Note

I wrote these two fixes to support ebtables 2.0.0 (which supports user defined chains). If we can drop support of ebtables before 2.0.8 (released around year 2007 or 2008), we can decrease ebtables calls (by unifying `-N` [new chain] and `-P` [set chain's policy]).



# Issue 3 : Unnecessary ipXtables-specific things

ebtables.py looks very similar to ipXtables.py and they share unnecessary things.

* `ebtables` class doesn't need `ipv` member
* ebtables allows `nat` table policies to be `DROP`

## Severity

Middle to Low (ebtables support should not be harmed without those fixes).

## Fix

Commit cfc74142319c9a6de17291359d9b945d7a1a421c and 7d2774ed0a003367e50a1d6b6e50d6b33fbd2ad2 fix these.