### PR TITLE
Travis CI configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: python
+python:
+  - "2.7"
+  - "3.4"
+before_install:
+#  - "sudo add-apt-repository ppa:costamagnagianfranco/autoconf -y"
+  - "sudo apt-get update -qq"
+# dependencies
+install:
+  - "sudo apt-get install -y intltool desktop-file-utils xsltproc"
+#  - "sudo apt-get install -y python-dbus python3-dbus python-decorator python-gobject python3-gi"
+# command to run tests
+script: ./autogen.sh && make && make check && make distcheck
+notifications:
+  email: false

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 # Process this file with autoconf to produce a configure script.
 
-AC_PREREQ([2.69])
+AC_PREREQ([2.68])
 
 m4_define([PKG_NAME], firewalld)
 m4_define([PKG_VERSION], m4_bpatsubst(m4_esyscmd([grep "Version:" firewalld.spec]), [Version:\W\([0-9.]*\)\W], [\1]))


### PR DESCRIPTION
This commit adds .travis.yml - Travis CI configuration file.

There's a problem, that Travis runs Ubuntu-12.04 with autoconf-2.68, while we need autoconf-2.69, so it doesn't work so far. But I'm adding it, so it doesn't get lost.

I tried
http://askubuntu.com/questions/420991/install-autoconf-2-69-on-ubuntu-12-04
to work-around the problem but with no luck.

You can see (unsuccessful) runs here:
https://travis-ci.org/jpopelka/firewalld