### PR TITLE
add ceph services

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -75,6 +75,8 @@ EXTRA_DIST = \
 	services/amanda-k5-client.xml \
 	services/bacula-client.xml \
 	services/bacula.xml \
+	services/ceph.xml \
+	services/ceph-mon.xml \
 	services/dhcpv6-client.xml \
 	services/dhcpv6.xml \
 	services/dhcp.xml \

--- a/config/services/ceph-mon.xml
+++ b/config/services/ceph-mon.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>ceph-mon</short>
+  <description>Ceph is a distributed object store and file system. Enable this option to support Ceph's Monitor Daemon.</description>
+  <port protocol="tcp" port="3300"/>
+  <port protocol="tcp" port="6789"/>
+</service>

--- a/config/services/ceph.xml
+++ b/config/services/ceph.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>ceph</short>
+  <description>Ceph is a distributed object store and file system. Enable this option to support Ceph's Object Storage Daemons (OSD) or Metadata Server Daemons (MDS).</description>
+  <port protocol="tcp" port="6800-7300"/>
+</service>


### PR DESCRIPTION
Ceph's OSD and MDS daemons listen on TCP ports 6800 through 7300 by default.

Ceph's MON daemon listens on port 6789 by default.

This PR adds the "ceph" and "ceph-mon" service definitions for Ceph.