### PR TITLE
Fix typos in firewall-cmd helptext

### DIFF
--- a/src/firewall-cmd
+++ b/src/firewall-cmd
@@ -100,13 +100,13 @@ IcmpType Options
   --new-icmptype=<icmptype>
                        Add a new icmptype [P only]
   --delete-icmptype=<icmptype>
-                       Delete and existing icmptype [P only]
+                       Delete an existing icmptype [P only]
 
 Service Options
   --new-service=<service>
                        Add a new service [P only]
   --delete-service=<service>
-                       Delete and existing service [P only]
+                       Delete an existing service [P only]
 
 Options to Adapt and Query Zones
   --list-all           List everything added for or enabled in a zone [P] [Z]

--- a/src/firewall-offline-cmd
+++ b/src/firewall-offline-cmd
@@ -105,13 +105,13 @@ IcmpType Options
   --new-icmptype=<icmptype>
                        Add a new icmptype
   --delete-icmptype=<icmptype>
-                       Delete and existing icmptype
+                       Delete an existing icmptype
 
 Service Options
   --new-service=<service>
                        Add a new service
   --delete-service=<service>
-                       Delete and existing service
+                       Delete an existing service
 
 Options to Adapt and Query Zones
   --list-all           List everything added for or enabled in a zone [Z]


### PR DESCRIPTION
Fixes two small typos in the firewall-cmd and firewall-offline-cmd help
text.