### PR TITLE
add docker registry services

### DIFF
--- a/config/services/docker-registry.xml
+++ b/config/services/docker-registry.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Docker Registry</short>
+  <description>Docker Registry is the protocol used to serve Docker images. If you plan to make your Docker Registry server publicly available, enable this option. This option is not required for developing Docker images locally.</description>
+  <port protocol="tcp" port="5000"/>
+</service>

--- a/config/services/docker.xml
+++ b/config/services/docker.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Docker</short>
+  <description>Docker is the protocol used to control the Docker service remotely. If you plan to make your Docker server publicly available, enable this option. This option is not required for controlling Docker locally.</description>
+  <port protocol="tcp" port="2375"/>
+</service>

--- a/config/services/docker.xml
+++ b/config/services/docker.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<service>
-  <short>Docker</short>
-  <description>Docker is the protocol used to control the Docker service remotely. If you plan to make your Docker server publicly available, enable this option. This option is not required for controlling Docker locally.</description>
-  <port protocol="tcp" port="2375"/>
-</service>


### PR DESCRIPTION
I got tired of manually creating the services for docker and docker registry.

docker 2375/tcp used to remotely control docker servers
docker-registry 5000/tcp used to access docker registry servers