### PR TITLE
add bitcoin related services

### DIFF
--- a/config/services/bitcoin-rpc.xml
+++ b/config/services/bitcoin-rpc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Bitcoin RPC</short>
+  <description>Enable this option if you need access to the Bitcoin RPC interface.  This is not required when connecting on localhost.</description>
+  <port protocol="tcp" port="8332"/>
+</service>

--- a/config/services/bitcoin-testnet-rpc.xml
+++ b/config/services/bitcoin-testnet-rpc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Bitcoin testnet RPC</short>
+  <description>Enable this option if you need access to the Bitcoin RPC interface running on the testnet.  This is not required when connecting on localhost.</description>
+  <port protocol="tcp" port="18332"/>
+</service>

--- a/config/services/bitcoin-testnet.xml
+++ b/config/services/bitcoin-testnet.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Bitcoin testnet</short>
+  <description>The default port used by Bitcoin testnet.  Enable this option if you plan to be a Bitcoin full node on the test network.</description>
+  <port protocol="tcp" port="18333"/>
+</service>

--- a/config/services/bitcoin.xml
+++ b/config/services/bitcoin.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Bitcoin</short>
+  <description>The default port used by Bitcoin.  Enable this option if you plan to be a full Bitcoin node.</description>
+  <port protocol="tcp" port="8333"/>
+</service>


### PR DESCRIPTION
The following ports are used by bitcoin to connect to the network and provide full node capabilities.

bitcoin 8333/tcp
bitcoin-rpc 8332/tcp

The following ports are used by bitcoin to connect to the test network and provide full node capabilities.

bitcoin-testnet 18333/tcp
bitcoin-testnet-rpc 18332/tcp
