### PR TITLE
firewall: core: Use alternative paths for Xtables and ipset tools

### DIFF
--- a/src/firewall/core/ebtables.py
+++ b/src/firewall/core/ebtables.py
@@ -46,8 +46,9 @@ for table in BUILT_IN_CHAINS.keys():
 
 class ebtables(object):
     def __init__(self):
-        self._command = "/sbin/ebtables"
-        self._restore_command = "/sbin/ebtables-restore"
+        command_path = lambda cmd: cmd if os.path.exists(cmd) else "/usr" + cmd
+        self._command = command_path("/sbin/ebtables")
+        self._restore_command = command_path("/sbin/ebtables-restore")
         self.ebtables_lock = "/var/lib/ebtables/lock"
         self.__remove_dangling_lock()
 

--- a/src/firewall/core/ipXtables.py
+++ b/src/firewall/core/ipXtables.py
@@ -147,8 +147,10 @@ class ip4tables(object):
     ipv = "ipv4"
 
     def __init__(self):
-        self._command = COMMAND[self.ipv]
-        self._restore_command = RESTORE_COMMAND[self.ipv]
+        command_path = lambda cmd: cmd if os.path.exists(cmd) else "/usr" + cmd
+        self._command = command_path(COMMAND[self.ipv])
+        self._restore_command = command_path(RESTORE_COMMAND[self.ipv])
+
         self.wait_option = self._detect_wait_option()
 
     def __run(self, args):

--- a/src/firewall/core/ipset.py
+++ b/src/firewall/core/ipset.py
@@ -57,7 +57,8 @@ IPSET_CREATE_OPTIONS = {
 
 class ipset:
     def __init__(self):
-        self._command = "/usr/sbin/ipset"
+        command_path = lambda cmd: cmd if os.path.exists(cmd) else "/usr" + cmd
+        self._command = command_path("/sbin/ipset")
 
     def __run(self, args):
         # convert to string list


### PR DESCRIPTION
Fallback to '/usr/sbin' if ebtables, ipset or ip{4,6}tables are not
installed in '/sbin'.