### PR TITLE
config: firewalld.service: Drop Standard{Output,Error}

### DIFF
--- a/config/firewalld.service.in
+++ b/config/firewalld.service.in
@@ -9,9 +9,6 @@ Conflicts=iptables.service ip6tables.service ebtables.service ipset.service
 EnvironmentFile=-/etc/sysconfig/firewalld
 ExecStart=@sbindir@/firewalld --nofork --nopid $FIREWALLD_ARGS
 ExecReload=/bin/kill -HUP $MAINPID
-# supress to log debug and error output also to /var/log/messages
-StandardOutput=null
-StandardError=null
 Type=dbus
 BusName=org.fedoraproject.FirewallD1
 


### PR DESCRIPTION
Drop the Standard{Output,Error}=null options so we can use the system
logger to find out what firewalld is doing. It also helps when using
--debug in /etc/sysconfig/firewalld as well