### PR TITLE
Add ManageSieve service

### DIFF
--- a/config/services/managesieve.xml
+++ b/config/services/managesieve.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>ManageSieve</short>
+  <description>The ManageSieve Protocol allows a local client to manage eMail sieve scripts on a remote server. If you plan to provide a ManageSieve service (e.g. with dovecot pigeonhole), enable this option.</description>
+  <port protocol="tcp" port="4190"/>
+</service>


### PR DESCRIPTION
Hello

this pull request adds a service file for the ManageSieve [RFC5804] protocol.  The service file
opens port 4190 for TCP transport as described in the RFC.  It would be great to see this file
added to the project.

[RFC5804]: https://tools.ietf.org/html/rfc5804