### PR TITLE
Add options --save-default-zone, --get-saved-zone, --restore-saved-zone

### DIFF
--- a/doc/xml/firewall-cmd.xml
+++ b/doc/xml/firewall-cmd.xml
@@ -218,6 +218,33 @@
 	</varlistentry>
 
 	<varlistentry>
+	  <term><option>--save-default-zone</option></term>
+	  <listitem>
+	    <para>
+	      Save current default zone name for future restore
+	    </para>
+	  </listitem>
+	</varlistentry>
+
+	<varlistentry>
+	  <term><option>--get-saved-zone</option></term>
+	  <listitem>
+	    <para>
+	      Print current saved zone
+	    </para>
+	  </listitem>
+	</varlistentry>
+
+	<varlistentry>
+	  <term><option>--restore-saved-zone</option></term>
+	  <listitem>
+	    <para>
+	      Set saved zone as default
+	    </para>
+	  </listitem>
+	</varlistentry>
+
+	<varlistentry>
 	  <term><option>--get-active-zones</option></term>
 	  <listitem>
 	    <para>

--- a/doc/xml/firewall-offline-cmd.xml
+++ b/doc/xml/firewall-offline-cmd.xml
@@ -267,6 +267,33 @@
 	  </listitem>
 	</varlistentry>
 
+        <varlistentry>
+          <term><option>--save-default-zone</option></term>
+          <listitem>
+            <para>
+              Save current default zone name for future restore
+            </para>
+          </listitem>
+        </varlistentry>
+
+        <varlistentry>
+          <term><option>--get-saved-zone</option></term>
+          <listitem>
+            <para>
+              Print current saved zone
+            </para>
+          </listitem>
+        </varlistentry>
+
+        <varlistentry>
+          <term><option>--restore-saved-zone</option></term>
+          <listitem>
+            <para>
+              Set saved zone as default
+            </para>
+          </listitem>
+        </varlistentry>
+
 	<varlistentry>
 	  <term><option>--set-default-zone</option>=<replaceable>zone</replaceable></term>
 	  <listitem>

--- a/shell-completion/bash/firewall-cmd
+++ b/shell-completion/bash/firewall-cmd
@@ -91,6 +91,7 @@ OPTIONS_GENERAL="--help --version \
                  --get-log-denied --set-log-denied= \
                  --lockdown-on --lockdown-off --query-lockdown \
                  --get-default-zone --set-default-zone= --get-active-zones \
+                 --save-default-zone --get-saved-zone --restore-saved-zone \
                  --get-zone-of-interface= --get-zone-of-interface= \
                  ${OPTIONS_CONFIG} \
                  --zone= ${OPTIONS_ZONE} \

--- a/src/firewall-cmd
+++ b/src/firewall-cmd
@@ -101,6 +101,10 @@ Zone Options
   --info-zone=<zone>   Print information about a zone
   --path-zone=<zone>   Print file path of a zone [P only]
 
+  --save-default-zone  Save current default zone name for future restore
+  --get-saved-zone     Print current saved zone
+  --restore-saved-zone Set saved zone as default
+
 IPSet Options
   --new-ipset=<ipset> --type=<ipset type> [--option=<key>[=<value>]]..
                        Add a new ipset [P only]
@@ -518,6 +522,10 @@ parser_group_standalone.add_argument("--info-service", metavar="<service>")
 parser_group_standalone.add_argument("--info-icmptype", metavar="<icmptype>")
 parser_group_standalone.add_argument("--info-ipset", metavar="<ipset>")
 
+parser_group_standalone.add_argument("--save-default-zone", action="store_true")
+parser_group_standalone.add_argument("--get-saved-zone", action="store_true")
+parser_group_standalone.add_argument("--restore-saved-zone", action="store_true")
+
 parser_group_config = parser.add_mutually_exclusive_group()
 parser_group_config.add_argument("--new-icmptype", metavar="<icmptype>")
 parser_group_config.add_argument("--delete-icmptype", metavar="<icmptype>")
@@ -704,7 +712,8 @@ options_standalone = a.help or a.version or \
     a.panic_on or a.panic_off or a.query_panic or \
     a.lockdown_on or a.lockdown_off or a.query_lockdown or \
     a.get_default_zone or a.set_default_zone or \
-    a.get_active_zones or a.get_log_denied or a.set_log_denied
+    a.get_active_zones or a.get_log_denied or a.set_log_denied or \
+    a.save_default_zone or a.get_saved_zone or a.restore_saved_zone
 
 options_lockdown_whitelist = \
     a.list_lockdown_whitelist_commands or a.add_lockdown_whitelist_command or \
@@ -800,7 +809,8 @@ options_list_get = a.help or a.version or a.list_all or a.list_all_zones or \
  a.get_services or a.get_icmptypes or a.get_target or \
  a.info_zone or a.info_icmptype or a.info_service or \
  a.info_ipset or a.get_ipsets or a.get_entries or \
- a.get_destinations
+ a.get_destinations or a.save_default_zone or a.get_saved_zone or \
+ a.restore_saved_zone
 
 # Check various impossible combinations of options
 
@@ -1602,6 +1612,29 @@ elif a.set_default_zone:
     fw.setDefaultZone(a.set_default_zone)
 elif a.get_zones:
     __print_and_exit(" ".join(fw.getZones()))
+elif a.save_default_zone:
+    default_zone = fw.getDefaultZone()
+    with open(FIREWALLD_SAVED_ZONE, 'w') as f:
+        f.write(default_zone)
+        __print_and_exit("Current zone %s saved in %s" % (default_zone,
+                                                          FIREWALLD_SAVED_ZONE))
+elif a.get_saved_zone:
+    if os.path.exists(FIREWALLD_SAVED_ZONE):
+        with open(FIREWALLD_SAVED_ZONE, 'r') as f:
+            __print_and_exit("%s" % f.read(), exit_code=0)
+    __print_and_exit("No zone saved previously")
+elif a.restore_saved_zone:
+    saved_zone = None
+    if os.path.exists(FIREWALLD_SAVED_ZONE):
+        with open(FIREWALLD_SAVED_ZONE, 'r') as f:
+            saved_zone = f.read().strip()
+
+        if saved_zone is not None:
+            fw.setDefaultZone(saved_zone)
+            os.unlink(FIREWALLD_SAVED_ZONE)
+            __print_and_exit("Default zone now is: %s" % saved_zone)
+
+    __print_and_exit("No zone saved previously")
 elif a.get_active_zones:
     zones = fw.getActiveZones()
     for zone in zones:

--- a/src/firewall-offline-cmd
+++ b/src/firewall-offline-cmd
@@ -102,6 +102,10 @@ Zone Options
                        Set the zone target
   --info-zone=<zone>   Print information about a zone
 
+  --save-default-zone  Save current default zone name for future restore
+  --get-saved-zone     Print current saved zone
+  --restore-saved-zone Set saved zone as default
+
 IPSet Options
   --new-ipset=<ipset> --type=<ipset type> [--option=<key>[=<value>]]..
                        Add a new ipset
@@ -550,6 +554,10 @@ parser_group_standalone.add_argument("--info-service", metavar="<service>")
 parser_group_standalone.add_argument("--info-icmptype", metavar="<icmptype>")
 parser_group_standalone.add_argument("--info-ipset", metavar="<ipset>")
 
+parser_group_standalone.add_argument("--save-default-zone", action="store_true")
+parser_group_standalone.add_argument("--get-saved-zone", action="store_true")
+parser_group_standalone.add_argument("--restore-saved-zone", action="store_true")
+
 parser_group_config = parser.add_mutually_exclusive_group()
 parser_group_config.add_argument("--new-icmptype", metavar="<icmptype>")
 parser_group_config.add_argument("--delete-icmptype", metavar="<icmptype>")
@@ -737,7 +745,8 @@ options_lokkit = a.enabled or a.disabled or a.addmodule or a.removemodule or \
 options_standalone = a.help or a.version or \
     a.policy_server or a.policy_desktop or \
     a.lockdown_on or a.lockdown_off or a.query_lockdown or \
-    a.get_default_zone or a.set_default_zone
+    a.get_default_zone or a.set_default_zone or \
+    a.save_default_zone or a.get_saved_zone or a.restore_saved_zone
 
 options_lockdown_whitelist = \
     a.list_lockdown_whitelist_commands or a.add_lockdown_whitelist_command or \
@@ -824,6 +833,7 @@ options_list_get = a.help or a.version or a.list_all or a.list_all_zones or \
  a.list_forward_ports or a.list_rich_rules or a.list_interfaces or \
  a.list_sources or \
  a.get_default_zone or a.get_zone_of_interface or \
+ a.save_default_zone or a.get_saved_zone or a.restore_saved_zone or \
  a.get_zone_of_source or a.get_zones or a.get_services or a.get_icmptypes or \
  a.get_target or a.set_target or \
  a.info_zone or a.info_icmptype or a.info_service or \
@@ -966,7 +976,29 @@ try:
         __print_and_exit(fw.get_default_zone())
     elif a.set_default_zone:
         fw.set_default_zone(a.set_default_zone)
+    elif a.save_default_zone:
+        default_zone = fw.get_default_zone()
+        with open(FIREWALLD_SAVED_ZONE, 'w') as f:
+            f.write(default_zone)
+            __print_and_exit("Current zone %s saved in %s" % (default_zone,
+                                                              FIREWALLD_SAVED_ZONE))
+    elif a.get_saved_zone:
+        if os.path.exists(FIREWALLD_SAVED_ZONE):
+            with open(FIREWALLD_SAVED_ZONE, 'r') as f:
+                __print_and_exit("%s" % f.read(), exit_code=0)
+        __print_and_exit("No zone saved previously")
+    elif a.restore_saved_zone:
+        saved_zone = None
+        if os.path.exists(FIREWALLD_SAVED_ZONE):
+            with open(FIREWALLD_SAVED_ZONE, 'r') as f:
+                saved_zone = f.read().strip()
 
+            if saved_zone is not None:
+                fw.set_default_zone(saved_zone)
+                os.unlink(FIREWALLD_SAVED_ZONE)
+                __print_and_exit("Default zone now is: %s" % saved_zone)
+
+        __print_and_exit("No zone saved previously")
     # lockdown
     elif a.lockdown_on:
         fw.enable_lockdown()

--- a/src/firewall/config/__init__.py.in
+++ b/src/firewall/config/__init__.py.in
@@ -79,6 +79,8 @@ FIREWALLD_DIRECT = ETC_FIREWALLD + '/direct.xml'
 
 LOCKDOWN_WHITELIST = ETC_FIREWALLD + '/lockdown-whitelist.xml'
 
+FIREWALLD_SAVED_ZONE = FIREWALLD_ZONES + '/zone_saved'
+
 SYSCTL_CONFIG = '/etc/sysctl.conf'
 
 # commands used by backends


### PR DESCRIPTION
In order to save the current default zone for later restore it this
patch adds the options --save-default-zone, --get-saved-zone, --restore-saved-zone.

An use case as example:
A program ships a zone and before setting it as default during
the instalation it could get the current default zone and save it
for when removing the software can restore the previous default zone.