### PR TITLE
Remove automake generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@
 /doc/man/man5/*.5
 /doxygen.conf
 /firewalld-*.tar.bz2
+/install-sh
+/missing
 /po/*
 /src/firewall/config/__init__.py
 Makefile

--- a/install-sh
+++ b/install-sh
@@ -1,1 +1,0 @@
-/usr/share/automake-1.15/install-sh

--- a/missing
+++ b/missing
@@ -1,1 +1,0 @@
-/usr/share/automake-1.15/missing


### PR DESCRIPTION
'install-sh' and 'missing' files depend on the build host so they
shouldn't be part of the git sources. autogen.sh will normally regenerate
these by symlinking them from the system files so they may always appear
as modified when building firewalld from the checked out sources.