### PR TITLE
src: Makefile.am: Run fix_python_shebang.sh after binaries are in place

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -61,7 +61,7 @@ EXTRA_DIST = \
 
 CLEANFILES = *~ *\# .\#* *.py?
 
-install-data-local:
+install-data-local: install-dist_sbinSCRIPTS install-dist_binSCRIPTS
 	@echo "Fixing python shebang"
 	@list='$(dist_bin_SCRIPTS)'; \
 	for p in $$list; do \


### PR DESCRIPTION
When performing a parallel installation on big systems, there is a race
condition when fix_python_shebang.sh is executed before the binaries are
installed leading to installation failures. Add missing dependencies to
fix this problem.