### PR TITLE
Only use first part when checking zone name length

### DIFF
--- a/src/firewall/core/io/zone.py
+++ b/src/firewall/core/io/zone.py
@@ -217,7 +217,7 @@ class Zone(IO_Object):
             raise FirewallError(INVALID_NAME, "'%s' can't end with '/'" % name)
         elif name.count('/') > 1:
             raise FirewallError(INVALID_NAME, "more than one '/' in '%s'" % name)
-        elif len(name) > max_zone_name_len():
+        elif len(name[name.find('/')]) > max_zone_name_len():
             raise FirewallError(INVALID_NAME,
                                 "'%s' has %d chars, max is %d" % (name, len(name), max_zone_name_len()))
 


### PR DESCRIPTION
This fixes the error:

INVALID_NAME 'myzone/00_a_very_long_and_descriptive_name' has 42 chars, max is 17

Which is wrong since only the first part of the zone name should be checked (since that is what is used in iptables).