### PR TITLE
src: firewall-cmd: Make --{get,set}-{short,description} permanent opt…

### DIFF
--- a/src/firewall-cmd
+++ b/src/firewall-cmd
@@ -839,7 +839,7 @@ options_permanent_only = a.new_icmptype or a.delete_icmptype or \
                          (a.icmptype and options_icmptype) or \
                          (a.service and options_service) or \
                          a.path_zone or a.path_icmptype or a.path_service or \
-                         a.path_ipset
+                         a.path_ipset or options_desc_xml_file
 
 options_direct = a.passthrough or \
            a.add_chain or a.remove_chain or a.query_chain or \


### PR DESCRIPTION
…ions

--{get,set}--{short,description} can only be used with --permanent so
make sure firewall-cmd will refuse to execute them in any other case.