### PR TITLE
Adding IANA-registered sip (SIP) and sips (SIP-TLS) services (RFC3263).

### DIFF
--- a/config/services/sip.xml
+++ b/config/services/sip.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>SIP</short>
+  <description>The Session Initiation Protocol (SIP) is a communications protocol for signaling and controlling multimedia communication sessions. The most common applications of SIP are in Internet telephony for voice and video calls, as well as instant messaging, over Internet Protocol (IP) networks.</description>
+  <port protocol="tcp" port="5060"/>
+  <port protocol="udp" port="5060"/>
+</service>

--- a/config/services/sips.xml
+++ b/config/services/sips.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>SIP-TLS (SIPS)</short>
+  <description>SIP-TLS is a modified SIP (Session Initiation Protocol) using TLS for secure signaling.</description>
+  <port protocol="tcp" port="5061"/>
+  <port protocol="udp" port="5061"/>
+</service>


### PR DESCRIPTION
This adds two new services:
- SIP (sip) on 5060/tcp and 5060/udp.
- SIP-TLS (sips) on 5061/tcp and 5061/udp.

PS: Obviously, disregard my patch sent directly via the ML earlier this week, but I suppose [this page](http://www.firewalld.org/contribute/) should be clarified.