### PR TITLE
configure.ac: Autodetect the {ip,ip6,eb}tables{,-restore} tools

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -62,40 +62,43 @@ AC_ARG_WITH([bashcompletiondir],
        [BASHCOMPLETIONDIR=$withval], [BASHCOMPLETIONDIR="${datadir}/bash-completion/completions"])
 AC_SUBST(BASHCOMPLETIONDIR)
 
-AC_ARG_WITH([iptables],
-       AS_HELP_STRING([--with-iptables], [Path to iptables executable]),
-       [IPTABLES=$withval], [IPTABLES="/usr/sbin/iptables"])
-AC_SUBST(IPTABLES)
+# Extend PATH to include /sbin etc in case we are building as non-root
+FW_TOOLS_PATH="$PATH:/usr/local/sbin:/sbin:/usr/sbin"
 
-AC_ARG_WITH([iptables-restore],
-       AS_HELP_STRING([--with-iptables-restore], [Path to iptables-restore executable]),
-       [IPTABLES_RESTORE=$withval], [IPTABLES_RESTORE="/usr/sbin/iptables-restore"])
-AC_SUBST(IPTABLES_RESTORE)
+AC_PATH_PROG([IPTABLES], [iptables], [], [$FW_TOOLS_PATH])
+if test "x$IPTABLES" = "x"; then
+    AC_MSG_ERROR([iptables was not found in $FW_TOOLS_PATH])
+fi
 
-AC_ARG_WITH([ip6tables],
-       AS_HELP_STRING([--with-ip6tables], [Path to ip6tables executable]),
-       [IP6TABLES=$withval], [IP6TABLES="/usr/sbin/ip6tables"])
-AC_SUBST(IP6TABLES)
+AC_PATH_PROG([IPTABLES_RESTORE], [iptables-restore], [], [$FW_TOOLS_PATH])
+if test "x$IPTABLES_RESTORE" = "x"; then
+    AC_MSG_ERROR([iptables-restore was not found in $FW_TOOLS_PATH])
+fi
 
-AC_ARG_WITH([ip6tables-restore],
-       AS_HELP_STRING([--with-ip6tables-restore], [Path to ip6tables-restore executable]),
-       [IP6TABLES_RESTORE=$withval], [IP6TABLES_RESTORE="/usr/sbin/ip6tables-restore"])
-AC_SUBST(IP6TABLES_RESTORE)
+AC_PATH_PROG([IP6TABLES], [ip6tables], [], [$FW_TOOLS_PATH])
+if test "x$IP6TABLES" = "x"; then
+    AC_MSG_ERROR([ip6tables was not found in $FW_TOOLS_PATH])
+fi
 
-AC_ARG_WITH([ebtables],
-       AS_HELP_STRING([--with-ebtables], [Path to ebtables executable]),
-       [EBTABLES=$withval], [EBTABLES="/usr/sbin/ebtables"])
-AC_SUBST(EBTABLES)
+AC_PATH_PROG([IP6TABLES_RESTORE], [ip6tables-restore], [], [$FW_TOOLS_PATH])
+if test "x$IP6TABLES_RESTORE" = "x"; then
+    AC_MSG_ERROR([ip6tables-restore was not found in $FW_TOOLS_PATH])
+fi
 
-AC_ARG_WITH([ebtables-restore],
-       AS_HELP_STRING([--with-ebtables-restore], [Path to ebtables-restore executable]),
-       [EBTABLES_RESTORE=$withval], [EBTABLES_RESTORE="/usr/sbin/ebtables-restore"])
-AC_SUBST(EBTABLES_RESTORE)
+AC_PATH_PROG([EBTABLES], [ebtables], [], [$FW_TOOLS_PATH])
+if test "x$EBTABLES" = "x"; then
+    AC_MSG_ERROR([ebtables was not found in $FW_TOOLS_PATH])
+fi
 
-AC_ARG_WITH([ipset],
-       AS_HELP_STRING([--with-ipset], [Path to ipset executable]),
-       [IPSET=$withval], [IPSET="/usr/sbin/ipset"])
-AC_SUBST(IPSET)
+AC_PATH_PROG([EBTABLES_RESTORE], [ebtables-restore], [], [$FW_TOOLS_PATH])
+if test "x$EBTABLES_RESTORE" = "x"; then
+    AC_MSG_ERROR([ebtables-restore was not found in $FW_TOOLS_PATH])
+fi
+
+AC_PATH_PROG([IPSET], [ipset], [], [$FW_TOOLS_PATH])
+if test "x$IPSET" = "x"; then
+    AC_MSG_ERROR([ipset was not found in $FW_TOOLS_PATH])
+fi
 
 #############################################################
 


### PR DESCRIPTION
Assuming a default path for these tools is error-prone since distributions
install these tools into different places and not all packagers make
use of the --with-* switches to set the correct path. As a result of which,
rework the code to use the standard autoconf macros to detect the path for
these tools during the configure phase. Fixes #95