### PR TITLE
src: firewall-offline-cmd: Use env variable to select a different config file

### DIFF
--- a/doc/xml/firewall-offline-cmd.xml
+++ b/doc/xml/firewall-offline-cmd.xml
@@ -68,7 +68,16 @@
   <refsect1 id="options">
     <title>Options</title>
     <para>
-      If no options are given, configuration from <command>/etc/sysconfig/system-config-firewall</command> will be migrated.
+      If no options are given, the following files will be checked (in the listed order)
+      for valid configuration data:
+      <itemizedlist>
+        <listitem>
+            <para>File pointed by the <envar>FW_SYSCONFIG_FILE</envar> environmental variable</para>
+        </listitem>
+        <listitem>
+            <para><command>/etc/sysconfig/system-config-firewall</command></para>
+        </listitem>
+    </itemizedlist>
     </para>
     <para>
       The following options are supported:

--- a/src/firewall-offline-cmd
+++ b/src/firewall-offline-cmd
@@ -44,7 +44,11 @@ def __usage():
     print ("""
 Usage: firewall-offline-cmd [OPTIONS...]
 
-If no options are given, configuration from '/etc/sysconfig/system-config-firewall' will be migrated.
+If no options are given, the following files will be checked (in the listed order)
+for valid configuration data:
+
+  - File pointed by the FW_SYSCONFIG_FILE environmental variable
+  - /etc/sysconfig/system-config-firewall
 
 General Options
   -h, --help           Prints a short help text and exists
@@ -531,7 +535,10 @@ def __pk_symlink(product='server'):
         __fail('no such file '+_PK_DIR+_PK_NAME+product+'.policy')
 
 # system-config-firewall: fw_sysconfig
-CONF = '/etc/sysconfig/system-config-firewall'
+CONF = os.environ.get('FW_SYSCONFIG_FILE')
+if not CONF:
+    CONF = '/etc/sysconfig/system-config-firewall'
+
 def read_sysconfig_args():
     filename = None
     if os.path.exists(CONF) and os.path.isfile(CONF):


### PR DESCRIPTION
Allow users to import their firewall configuration from a different
configuration file using the FW_SYSCONFIG_FILE environmental variable.