### PR TITLE
firewall-{,offlind}-cmd: Fix option for setting the destination address

### DIFF
--- a/doc/xml/firewall-cmd.xml
+++ b/doc/xml/firewall-cmd.xml
@@ -1301,7 +1301,7 @@
        </varlistentry>
 
        <varlistentry>
-         <term><option>--permanent</option> <option>--service</option>=<replaceable>service</replaceable> <option>--add-destination</option>=<replaceable>ipv</replaceable>:<replaceable>address</replaceable><optional>/<replaceable>mask</replaceable></optional></term>
+         <term><option>--permanent</option> <option>--service</option>=<replaceable>service</replaceable> <option>--set-destination</option>=<replaceable>ipv</replaceable>:<replaceable>address</replaceable><optional>/<replaceable>mask</replaceable></optional></term>
          <listitem>
            <para>
              Set destination for ipv to address[/mask] in the permanent service.

--- a/doc/xml/firewall-offline-cmd.xml
+++ b/doc/xml/firewall-offline-cmd.xml
@@ -1191,7 +1191,7 @@
        </varlistentry>
 
        <varlistentry>
-         <term><option>--service</option>=<replaceable>service</replaceable> <option>--add-destination</option>=<replaceable>ipv</replaceable>:<replaceable>address</replaceable><optional>/<replaceable>mask</replaceable></optional></term>
+         <term><option>--service</option>=<replaceable>service</replaceable> <option>--set-destination</option>=<replaceable>ipv</replaceable>:<replaceable>address</replaceable><optional>/<replaceable>mask</replaceable></optional></term>
          <listitem>
            <para>
              Set destination for ipv to address[/mask] in the permanent service.

--- a/src/firewall-cmd
+++ b/src/firewall-cmd
@@ -215,7 +215,7 @@ Service Options
                        Return whether the module has been added for service [P only]
   --service=<service> --get-modules
                        List modules of service [P only]
-  --service=<service> --add-destination=<ipv>:<address>[/<mask>]
+  --service=<service> --set-destination=<ipv>:<address>[/<mask>]
                        Set destination for ipv to address in service [P only]
   --service=<service> --remove-destination=<ipv>
                        Disable destination for ipv i service [P only]

--- a/src/firewall-offline-cmd
+++ b/src/firewall-offline-cmd
@@ -196,7 +196,7 @@ Service Options
                        Return whether the module has been added for service
   --service=<service> --get-modules
                        List modules of service
-  --service=<service> --add-destination=<ipv>:<address>[/<mask>]
+  --service=<service> --set-destination=<ipv>:<address>[/<mask>]
                        Set destination for ipv to address in service
   --service=<service> --remove-destination=<ipv>
                        Disable destination for ipv i service


### PR DESCRIPTION
FirewallD services use --set-destination to set the destination address
for a service instead of --add-destination which is used for icmptypes.
As such, fix the help messages and the related manpages.