### PR TITLE
firewall-cmd: Fix typo

### DIFF
--- a/src/firewall-cmd
+++ b/src/firewall-cmd
@@ -72,7 +72,7 @@ General Options
 Status Options
   --state              Return and print firewalld state
   --reload             Reload firewall and keep state information
-  --complete-reload    Reload firewall and loose state information
+  --complete-reload    Reload firewall and lose state information
   --runtime-to-permanent
                        Create permanent from runtime configuration
   --get-log-denied     Print the log denied value


### PR DESCRIPTION
Just a small correction in the help text.