### PR TITLE
src: firewall: core: Drop unneeded python shebangs

### DIFF
--- a/src/firewall/core/fw_ifcfg.py
+++ b/src/firewall/core/fw_ifcfg.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2010-2016 Red Hat, Inc.

--- a/src/firewall/core/fw_nm.py
+++ b/src/firewall/core/fw_nm.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2010-2016 Red Hat, Inc.


### PR DESCRIPTION
The fw_ifcfg and fw_nm files are not supposed to be executed as
standalone files but rather imported by the main firewalld code so drop
the python shebangs. This also fixes a warning when building firewalld
in openSUSE OBS:

firewalld.noarch: W: non-executable-script
/usr/lib/python2.7/site-packages/firewall/core/fw_nm.py 644 /usr/bin/python
firewalld.noarch: W: non-executable-script
/usr/lib/python2.7/site-packages/firewall/core/fw_ifcfg.py 644 /usr/bin/python