### PR TITLE
firewall: core: fw_ifcfg: Quickly return if ifcfg directory does not exist

### DIFF
--- a/src/firewall/core/fw_ifcfg.py
+++ b/src/firewall/core/fw_ifcfg.py
@@ -32,6 +32,10 @@ from firewall.core.io.ifcfg import ifcfg
 def search_ifcfg_of_interface(interface):
     """search ifcfg file for the interface in config.IFCFGDIR"""
 
+    # Return quickly if config.IFCFGDIR does not exist
+    if not os.path.exists(config.IFCFGDIR):
+        return None
+
     filename = "%s/ifcfg-%s" % (config.IFCFGDIR, interface)
     if os.path.exists(filename):
         ifcfg_file = ifcfg(filename)


### PR DESCRIPTION
It's possible for the ifcfg directory to be missing or named differently
so do not try to access it if it does not exist. This avoid warnings
during firewalld start up like the following one:

ERROR: Calling post func <function ifcfg_set_zone_of_interface at
0x7fb2f0d4fc80> (('', 'enp3s0')) failed: [Errno 2] No such file or
directory: '/etc/sysconfig/network-scripts'