### PR TITLE
Added RSH service

### DIFF
--- a/config/services/rsh.xml
+++ b/config/services/rsh.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>rsh</short>
+  <description>Rsh is a protocol for logging into remote machines. It is unencrypted, and provides little security from network snooping attacks. Enabling rsh is not recommended.</description>
+  <port port="514" protocol="tcp"/>
+</service>


### PR DESCRIPTION
My old VXWORKS boxes require RSH access for their boot and setup.  I've added the 'unencrypted' disclaimer from the telnet service to help clarify that this is not an advised service.