### PR TITLE
services ha: Allow corosync-qnetd port

### DIFF
--- a/config/services/high-availability.xml
+++ b/config/services/high-availability.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <service>
   <short>Red Hat High Availability</short>
-  <description>This allows you to use the Red Hat High Availability (previously named Red Hat Cluster Suite). Ports are opened for corosync, pcsd, pacemaker_remote and dlm.</description>
+  <description>This allows you to use the Red Hat High Availability (previously named Red Hat Cluster Suite). Ports are opened for corosync, pcsd, pacemaker_remote, dlm and corosync-qnetd.</description>
   <port protocol="tcp" port="2224"/>
   <port protocol="tcp" port="3121"/>
+  <port protocol="tcp" port="5403"/>
   <port protocol="udp" port="5404"/>
   <port protocol="udp" port="5405"/>
   <port protocol="tcp" port="21064"/>


### PR DESCRIPTION
Corosync is getting new daemon used as quorum network arbiter called
corosync-qnetd. This daemon is running outside of cluster and
comunication is going on tcp port 5403.