### PR TITLE
config/firewalld.service.in: use network-pre.target

### DIFF
--- a/config/firewalld.service.in
+++ b/config/firewalld.service.in
@@ -16,6 +16,7 @@ StandardOutput=null
 StandardError=null
 Type=dbus
 BusName=org.fedoraproject.FirewallD1
+KillMode=mixed
 
 [Install]
 WantedBy=multi-user.target

--- a/config/firewalld.service.in
+++ b/config/firewalld.service.in
@@ -1,8 +1,7 @@
 [Unit]
 Description=firewalld - dynamic firewall daemon
-Before=network.target
-Before=libvirtd.service
-Before=NetworkManager.service
+Before=network-pre.target
+Wants=network-pre.target
 After=dbus.service
 After=polkit.service
 Conflicts=iptables.service ip6tables.service ebtables.service ipset.service
@@ -19,5 +18,5 @@ Type=dbus
 BusName=org.fedoraproject.FirewallD1
 
 [Install]
-WantedBy=basic.target
+WantedBy=multi-user.target
 Alias=dbus-org.fedoraproject.FirewallD1.service


### PR DESCRIPTION
Firewall services should be ordered before network-pre.target and should pull it, according to : https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/

This avoid any specific and fixed 'Before=' dependencies for NetworkManager and libvirtd as those services properly order themselves after network-pre.target or network.target.