### PR TITLE
firewallctl manpage

### DIFF
--- a/doc/man/man1/Makefile.am
+++ b/doc/man/man1/Makefile.am
@@ -1,6 +1,7 @@
 EXTRA_DIST = $(man_MANS)
 
 man_MANS = \
+	firewallctl.1 \
 	firewall-applet.1 \
 	firewall-cmd.1 \
 	firewall-config.1 \

--- a/firewalld.spec
+++ b/firewalld.spec
@@ -230,6 +230,7 @@ fi
 %{_datadir}/polkit-1/actions/org.fedoraproject.FirewallD1.server.policy
 %{_datadir}/polkit-1/actions/org.fedoraproject.FirewallD1.policy
 %{_mandir}/man1/firewall*cmd*.1*
+%{_mandir}/man1/firewallctl*.1*
 %{_mandir}/man1/firewalld*.1*
 %{_mandir}/man5/firewall*.5*
 


### PR DESCRIPTION
This pull request add the missing firewallctl.1 manpage to the installed files and also modifies the spec file accordingly.