### PR TITLE
Fix ICMP regression and speedup execution

### DIFF
--- a/src/firewall/core/fw_zone.py
+++ b/src/firewall/core/fw_zone.py
@@ -171,7 +171,7 @@ class FirewallZone(object):
 
             zone_transaction = transaction.zone_transaction(zone)
 
-            # Do icmp block inversion before setting obj.applied
+            # register icmp block inversion setting but don't apply
             if obj.icmp_block_inversion:
                 self._error2warning(self.add_icmp_block_inversion, obj.name,
                                     use_zone_transaction=zone_transaction)
@@ -211,6 +211,11 @@ class FirewallZone(object):
                                     use_zone_transaction=zone_transaction)
             for args in obj.sources:
                 self._error2warning(self.add_source, obj.name, args,
+                                    use_zone_transaction=zone_transaction)
+            # apply icmp accept/reject rule always
+            if obj.applied:
+                self._error2warning(self.__icmp_block_inversion, True,
+                                    obj.name,
                                     use_zone_transaction=zone_transaction)
 
         if use_transaction is None:

--- a/src/firewall/core/prog.py
+++ b/src/firewall/core/prog.py
@@ -19,61 +19,29 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-__all__ = [ "runProg" ]
+import subprocess
 
-import os
-import resource # Resource usage information.
 
-maxfd = resource.getrlimit(resource.RLIMIT_NOFILE)[1]
-if maxfd == resource.RLIM_INFINITY:
-    maxfd = 1024
+__all__ = ["runProg"]
+
 
 def runProg(prog, argv=None, stdin=None):
     if argv is None:
-        argv = [ ]
+        argv = []
 
-    args = [ prog ] + argv
+    args = [prog] + argv
 
-    (rfd, wfd) = os.pipe()
-    pid = os.fork()
-    if pid == 0:
+    input_string = None
+    if stdin:
+        with open(stdin, 'r') as handle:
+            input_string = handle.read().encode()
 
-        # Iterate through and close all file descriptors.
-        for fd in range(0, maxfd):
-            if fd == wfd: # Do not close write end of pipe
-                continue
-            try:
-                os.close(fd)
-            except OSError:
-                # ERROR, fd wasn't open to begin with (ignored)
-                pass
+    env = {'LANG': 'C'}
+    process = subprocess.Popen(args, stdin=subprocess.PIPE,
+                               stdout=subprocess.PIPE, close_fds=True,
+                               env=env)
+    (output, _) = process.communicate(input_string)
+    if output is not None:
+        output = output.decode('utf-8', 'replace')
 
-        try:
-            if stdin is not None:
-                fd = os.open(stdin, os.O_RDONLY)
-            else:
-                fd = os.open("/dev/null", os.O_RDONLY)
-            if fd != 0:
-                os.dup2(fd, 0)
-                os.close(fd)
-            if wfd != 1:
-                os.dup2(wfd, 1)
-                os.close(wfd)
-            os.dup2(1, 2)
-            e = { "LANG": "C" }
-            os.execve(args[0], args, e)
-        finally:
-            # The use of os._exit is needed here, sys.exit is not an option
-            os._exit(255) # pylint: disable=W0212
-    os.close(wfd)
-
-    cret = b''
-    cout = os.read(rfd, 8192)
-    while cout:
-        cret += cout
-        cout = os.read(rfd, 8192)
-    os.close(rfd)
-    (dummy, status) = os.waitpid(pid, 0)
-
-    cret = cret.rstrip().decode('utf-8', 'replace')
-    return (status, cret)
+    return (process.returncode, output)


### PR DESCRIPTION
### Fix issue with running programs

In some cases, iptables commands are no longer effective.  After
starting firewalld, iptables -L, ip6tables -L are empty.

Using subprocess module to run programs instead of os.fork() fixes this
issue.  (Closes #131)

This also reduced the start and stop time for firewalld on a test
machine from 24 seconds to 4.5 seconds.  (Closes #132)

subprocess.run() is simpler to use but is only available in Python 3.5.

### Fix missing icmp rules for some zones

When a zone has some interfaces and is not the default zone, ICMP
allow/reject rules are not being set on firewalld startup.  This causes
all ICMP packets to be rejected on those zones.  Fix this by making sure
ICMP block inversion rule is always called during startup.
(Closes #130).