### PR TITLE
Fix regression with unavailable optional commands

### DIFF
--- a/src/firewall/core/prog.py
+++ b/src/firewall/core/prog.py
@@ -37,9 +37,13 @@ def runProg(prog, argv=None, stdin=None):
             input_string = handle.read().encode()
 
     env = {'LANG': 'C'}
-    process = subprocess.Popen(args, stdin=subprocess.PIPE,
-                               stdout=subprocess.PIPE, close_fds=True,
-                               env=env)
+    try:
+        process = subprocess.Popen(args, stdin=subprocess.PIPE,
+                                   stdout=subprocess.PIPE, close_fds=True,
+                                   env=env)
+    except OSError:
+        return (255, '')
+
     (output, _) = process.communicate(input_string)
     if output is not None:
         output = output.decode('utf-8', 'replace')


### PR DESCRIPTION
When a command is not available, new implementation of runProg() raises
OSError which is not being handled by the callers.  Earlier
implementation returned (255, '').  Emulate earlier behavior to fix
a regression that when optional commands are not available, firewalld
fails to ignore them properly.