### PR TITLE
Add UDP to transmission-client.xml service

### DIFF
--- a/config/services/transmission-client.xml
+++ b/config/services/transmission-client.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <service>
   <short>Transmission</short>
-  <description>Transmission is a lightweight GTK+ BitTorrent client.</description>
+  <description>Transmission is a lightweight BitTorrent client.</description>
   <port protocol="tcp" port="51413"/>
+  <port protocol="udp" port="51413"/>
 </service>


### PR DESCRIPTION
Added UDP protocol as both DHT and µTP are enabled in Transmission (and essential to modern-day BitTorrent) by default and they depend on UDP. 

Transmission help file says to enable both tcp and udp:
https://www.transmissionbt.com/help/gtk/2.9x/html/pfrouter.html

Removed reference to "GTK+" as there are termainl, Qt, web, and daemon variants too.