### PR TITLE
firewall: core: fw_nm: Instantiate the NM client only once

### DIFF
--- a/src/firewall/core/fw_nm.py
+++ b/src/firewall/core/fw_nm.py
@@ -31,13 +31,16 @@ try:
     gi.require_version('NM', '1.0')
 except ValueError:
     _nm_imported = False
+    _nm_client = None
 else:
     try:
         from gi.repository import NM
         _nm_imported = True
+        _nm_client = NM.Client.new(None)
     except (ImportError, ValueError):
         NetworkManager = None
         _nm_imported = False
+        _nm_client = None
 
 from firewall import errors
 from firewall.errors import FirewallError
@@ -56,6 +59,12 @@ def nm_is_imported():
     """
     return _nm_imported
 
+def nm_get_client():
+    """Returns the NM client object or None if the import of NM failed
+    @return NM.Client instance if import was successful, None otherwise
+    """
+    return _nm_client
+
 def nm_get_zone_of_connection(connection):
     """Get zone of connection from NM
     @param connection name
@@ -63,8 +72,7 @@ def nm_get_zone_of_connection(connection):
     """
     check_nm_imported()
 
-    client = NM.Client.new(None)
-    active_connections = client.get_active_connections()
+    active_connections = nm_get_client().get_active_connections()
 
     for active_con in active_connections:
         if active_con.get_id() == connection:
@@ -85,8 +93,7 @@ def nm_set_zone_of_connection(zone, connection):
     """
     check_nm_imported()
 
-    client = NM.Client.new(None)
-    active_connections = client.get_active_connections()
+    active_connections = nm_get_client().get_active_connections()
 
     for active_con in active_connections:
         con = active_con.get_connection()
@@ -112,8 +119,7 @@ def nm_get_connections(connections, connections_uuid):
 
     check_nm_imported()
 
-    client = NM.Client.new(None)
-    active_connections = client.get_active_connections()
+    active_connections = nm_get_client().get_active_connections()
 
     for active_con in active_connections:
         # ignore vpn devices for now
@@ -135,8 +141,7 @@ def nm_get_connection_of_interface(interface):
     """
     check_nm_imported()
 
-    client = NM.Client.new(None)
-    active_connections = client.get_active_connections()
+    active_connections = nm_get_client().get_active_connections()
 
     for active_con in active_connections:
         # ignore vpn devices for now


### PR DESCRIPTION
If the NM module is available, instantiate the NM client when the module
is imported instead of re-instantiating in every method.
This also fixes a side-effect in firewall-applet and firewall-config
when the [connectivity] section is used in NetworkManager.conf and the
remote end pointed by the 'uri' option is unavailable. In that case,
when a NM client is started, the NetworkManager will send a
PropertiesChanged signal to notify interested subscribers that the
remote end can't be reached. However, such signals are being handled by
the nm_signal_receiver method which instantiates a new NM client because
of the nm_get_connections call. This results in another PropertiesChanged
signal to be sent again so firewall-applet and firewall-config are stuck
in an infinite loop handling the said signal.

Link: https://bugzilla.opensuse.org/show_bug.cgi?id=992082
Signed-off-by: Markos Chandras <mchandras@suse.de>