### PR TITLE
firewall.core.logger: Use syslog.openlog()

### DIFF
--- a/src/firewall/core/logger.py
+++ b/src/firewall/core/logger.py
@@ -83,6 +83,12 @@ class _StderrLog(_StdoutLog):
 class _SyslogLog(_StdoutLog):
     fd = None
 
+    # Work around Python issue 27875, "Syslogs /usr/sbin/foo as /foo instead of as foo"
+    # (but using openlog explicitly might be better anyway)
+    #
+    # Set ident to basename, log PID as well, and log to facility "daemon".
+    syslog.openlog(sys.argv[0].split('/')[-1], syslog.LOG_PID, syslog.LOG_DAEMON)
+
     def write(self, data, level, logger, is_debug=0):
         priority = None
         if is_debug:


### PR DESCRIPTION
Fixes: #147

* Work around Python issue 27875, "Syslogs /usr/sbin/foo as /foo
  instead of as foo".  https://bugs.python.org/issue27875

* Set syslog logging ident (to basename), include daemon PID
  and log to facility "daemon" (instead of the default, "user").

---

Before, firewalld logs like this:

```
# firewall-cmd --permanent --delete-zone=test
Error: INVALID_ZONE: test

Aug 27 18:24:47 blackbox /firewalld: ERROR: INVALID_ZONE: test
```

After, it logs like this:

```
Sep  3 18:17:52 blackbox firewalld[1353]: ERROR: INVALID_ZONE: test
```

The code is supposed to be called at module loading time / once.