### PR TITLE
firewalld.spec: Add missing autotools dependencies

### DIFF
--- a/firewalld.spec
+++ b/firewalld.spec
@@ -13,6 +13,8 @@ URL:     http://www.firewalld.org
 License: GPLv2+
 Source0: https://github.com/t-woerner/firewalld/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 BuildArch: noarch
+BuildRequires: autoconf
+BuildRequires: automake
 BuildRequires: desktop-file-utils
 BuildRequires: gettext
 BuildRequires: intltool


### PR DESCRIPTION
Commit 0ab7673fd666 ("Fix build from spec without fedorahosted.org
archives") added 'autogen.sh' to the %prep phase but this script calls
'autoreconf' so we need to add the necessary autotools dependencies to
the spec file as well.

Fixes: 0ab7673fd666 ("Fix build from spec without fedorahosted.org archives")
Signed-off-by: Markos Chandras <mchandras@suse.de>