### PR TITLE
Fix misspelled word in documentation

### DIFF
--- a/doc/xml/firewall-cmd.xml
+++ b/doc/xml/firewall-cmd.xml
@@ -603,7 +603,7 @@
 	</varlistentry>
 
 	<varlistentry>
-	  <term><optional><option>--permanent</option></optional> <optional><option>--zone</option>=<replaceable>zone</replaceable></optional> <option>--remove-protcol</option>=<replaceable>protocol</replaceable></term>
+	  <term><optional><option>--permanent</option></optional> <optional><option>--zone</option>=<replaceable>zone</replaceable></optional> <option>--remove-protocol</option>=<replaceable>protocol</replaceable></term>
 	  <listitem>
 	    <para>
 	      Remove the protocol from <replaceable>zone</replaceable>. If zone is omitted, default zone will be used. This option can be specified multiple times.

--- a/doc/xml/firewall-offline-cmd.xml
+++ b/doc/xml/firewall-offline-cmd.xml
@@ -669,7 +669,7 @@
        </varlistentry>
 
        <varlistentry>
-         <term><optional><option>--zone</option>=<replaceable>zone</replaceable></optional> <option>--remove-protcol</option>=<replaceable>protocol</replaceable></term>
+         <term><optional><option>--zone</option>=<replaceable>zone</replaceable></optional> <option>--remove-protocol</option>=<replaceable>protocol</replaceable></term>
          <listitem>
            <para>
              Remove the protocol from <replaceable>zone</replaceable>. If zone is omitted, default zone will be used. This option can be specified multiple times.

--- a/doc/xml/firewalld.service.xml
+++ b/doc/xml/firewalld.service.xml
@@ -70,7 +70,7 @@
   &lt;short&gt;<replaceable>My Service</replaceable>&lt;/short&gt;
   &lt;description&gt;<replaceable>description</replaceable>&lt;/description&gt;
   &lt;port port="<replaceable>137</replaceable>" protocol="<replaceable>tcp</replaceable>"/&gt;
-  &lt;protcol value="<replaceable>igmp</replaceable>"/&gt;
+  &lt;protocol value="<replaceable>igmp</replaceable>"/&gt;
   &lt;module name="<replaceable>nf_conntrack_netbios_ns</replaceable>"/&gt;
   &lt;destination ipv4="<replaceable>224.0.0.251</replaceable>" ipv6="<replaceable>ff02::fb</replaceable>"/&gt;
 &lt;/service&gt;

--- a/doc/xml/firewalld.zone.xml
+++ b/doc/xml/firewalld.zone.xml
@@ -59,7 +59,7 @@
 
     <para>
       A firewalld zone configuration file contains the information for a zone.
-      These are the zone description, services, ports, protcols, icmp-blocks, masquerade, forward-ports and rich language rules in an XML file format.
+      These are the zone description, services, ports, protocols, icmp-blocks, masquerade, forward-ports and rich language rules in an XML file format.
       The file name has to be <replaceable>zone_name</replaceable>.xml where length of <replaceable>zone_name</replaceable> is currently limited to 17 chars.
     </para>
     <para>
@@ -74,7 +74,7 @@
   [ &lt;source address="<replaceable>address</replaceable>[/<replaceable>mask</replaceable>]"|mac="<replaceable>MAC</replaceable>"|ipset="<replaceable>ipset</replaceable>"/&gt; ]
   [ &lt;service name="<replaceable>string</replaceable>"/&gt; ]
   [ &lt;port port="<replaceable>portid</replaceable>[-<replaceable>portid</replaceable>]" protocol="<literal>tcp</literal>|<literal>udp</literal>|<literal>sctp</literal>|<literal>dccp</literal>"/&gt; ]
-  [ &lt;protcol value="<replaceable>protocol</replaceable>"/&gt; ]
+  [ &lt;protocol value="<replaceable>protocol</replaceable>"/&gt; ]
   [ &lt;icmp-block name="<replaceable>string</replaceable>"/&gt; ]
   [ &lt;icmp-block-inversion/&gt; ]
   [ &lt;masquerade/&gt; ]


### PR DESCRIPTION
Change "protcol" to "protocol" in documentation