### PR TITLE
Adding service file for nrpe.

### DIFF
--- a/config/services/nrpe.xml
+++ b/config/services/nrpe.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>NRPE</short>
+  <description>NRPE allows you to execute Nagios plugins on a remote host in as transparent a manner as possible.</description>
+  <port protocol="tcp" port="5666"/>
+</service>


### PR DESCRIPTION
Although the port isn't IANA registered to Nagios, it's fairly well
known (http://www.speedguide.net/port.php?port=5666).